### PR TITLE
removed pkg variable which required package.json

### DIFF
--- a/src/AcuitySchedulingOAuth.js
+++ b/src/AcuitySchedulingOAuth.js
@@ -5,7 +5,6 @@
 var AcuityScheduling = require('./AcuityScheduling');
 var querystring = require('querystring');
 var request = require('request');
-var pkg = require('../package');
 
 function AcuitySchedulingOAuth (config) {
 


### PR DESCRIPTION
The package.json was required in this package as `pkg` but  that variable was never called in the file.  As a result, I got an error when trying to use this package in a project w/ webpack. (I tried just using the json loader for webpack of course, but that didn't seem to solve the problem). I ended up having to remove this require from my project wondered if it might be better not to include it at all if it's not used.